### PR TITLE
:sparkles: Add allow undelegation through CPI

### DIFF
--- a/anchor-counter/Cargo.lock
+++ b/anchor-counter/Cargo.lock
@@ -729,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "delegation-program-sdk"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bdcce308b528b458c346a4fc1d249579e1272a6feb5b6d746f88cab6ecc7890"
+checksum = "3cefbc8411275aa419386962205ccc211e8db3c7fc915f13f851336fea4c167a"
 dependencies = [
  "borsh 0.10.3",
  "delegation-sdk-attribute-delegate",

--- a/anchor-counter/package.json
+++ b/anchor-counter/package.json
@@ -5,7 +5,7 @@
   },
   "dependencies": {
     "@coral-xyz/anchor": "^0.30.0",
-    "@magicblock-labs/delegation-program": "^0.1.1"
+    "@magicblock-labs/delegation-program": "^0.1.2"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.0",

--- a/anchor-counter/programs/anchor-counter/Cargo.toml
+++ b/anchor-counter/programs/anchor-counter/Cargo.toml
@@ -18,4 +18,4 @@ idl-build = ["anchor-lang/idl-build"]
 
 [dependencies]
 anchor-lang = "0.30.0"
-delegation-program-sdk = "0.1.0"
+delegation-program-sdk = "0.1.2"

--- a/anchor-counter/programs/anchor-counter/src/lib.rs
+++ b/anchor-counter/programs/anchor-counter/src/lib.rs
@@ -24,6 +24,25 @@ pub mod anchor_counter {
         Ok(())
     }
 
+
+    /// Allow undelegation if the counter is greater than 0.
+    pub fn allow_undelegation(ctx: Context<AllowUndelegation>) -> Result<()> {
+        let counter =
+            Counter::try_deserialize_unchecked(&mut (&**ctx.accounts.counter.try_borrow_data()?))?;
+        if counter.count > 0 {
+            msg!("Counter is greater than 0, undelegation is allowed");
+            delegation_program_sdk::allow_undelegation(
+                &ctx.accounts.counter,
+                &ctx.accounts.delegation_record,
+                &ctx.accounts.delegation_metadata,
+                &ctx.accounts.buffer,
+                &ctx.accounts.delegation_program,
+                &id(),
+            )?;
+        }
+        Ok(())
+    }
+
     /// Delegate the account to the delegation program
     pub fn delegate(ctx: Context<DelegateInput>) -> Result<()> {
         let pda_seeds: &[&[u8]] = &[TEST_PDA_SEED];
@@ -34,7 +53,7 @@ pub mod anchor_counter {
             &ctx.accounts.owner_program,
             &ctx.accounts.buffer,
             &ctx.accounts.delegation_record,
-            &ctx.accounts.delegate_account_seeds,
+            &ctx.accounts.delegation_metadata,
             &ctx.accounts.delegation_program,
             &ctx.accounts.system_program,
             pda_seeds,
@@ -71,11 +90,30 @@ pub struct DelegateInput<'info> {
     pub delegation_record: AccountInfo<'info>,
     /// CHECK: The seeds to create the delegate account
     #[account(mut)]
-    pub delegate_account_seeds: AccountInfo<'info>,
+    pub delegation_metadata: AccountInfo<'info>,
     /// CHECK: The delegation program ID
     pub delegation_program: AccountInfo<'info>,
     /// CHECK: The system program
     pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct AllowUndelegation<'info> {
+    #[account(seeds = [TEST_PDA_SEED], bump)]
+    /// CHECK: The counter pda
+    pub counter: AccountInfo<'info>,
+    #[account()]
+    /// CHECK: delegation record
+    pub delegation_record: AccountInfo<'info>,
+    #[account(mut)]
+    /// CHECK: delegation metadata
+    pub delegation_metadata: AccountInfo<'info>,
+    #[account()]
+    /// CHECK: singer buffer to enforce CPI
+    pub buffer: AccountInfo<'info>,
+    #[account()]
+    /// CHECK:`
+    pub delegation_program: AccountInfo<'info>,
 }
 
 /// Account for the increment instruction.

--- a/anchor-counter/programs/anchor-counter/src/lib.rs
+++ b/anchor-counter/programs/anchor-counter/src/lib.rs
@@ -24,7 +24,6 @@ pub mod anchor_counter {
         Ok(())
     }
 
-
     /// Allow undelegation if the counter is greater than 0.
     pub fn allow_undelegation(ctx: Context<AllowUndelegation>) -> Result<()> {
         let counter =

--- a/anchor-counter/tests/anchor-counter.ts
+++ b/anchor-counter/tests/anchor-counter.ts
@@ -73,7 +73,7 @@ describe("anchor-counter", () => {
     }
     const {
       delegationPda,
-      delegatedAccountSeedsPda,
+      delegationMetadata,
       bufferPda,
       commitStateRecordPda,
       commitStatePda,
@@ -86,7 +86,7 @@ describe("anchor-counter", () => {
         payer: provider.wallet.publicKey,
         pda: pda,
         ownerProgram: program.programId,
-        delegateAccountSeeds: delegatedAccountSeedsPda,
+        delegationMetadata: delegationMetadata,
         buffer: bufferPda,
         delegationRecord: delegationPda,
         delegationProgram: DELEGATION_PROGRAM_ID,
@@ -136,13 +136,26 @@ describe("anchor-counter", () => {
   });
 
   it("Undelegate the counter", async () => {
-    const ix = createUndelegateInstruction({
+    // Create the unlock undelegation instruction
+    const { delegationPda, delegationMetadata, bufferPda, commitStateRecordPda, commitStatePda} = DelegateAccounts(pda, program.programId);
+    let tx = await program.methods
+        .allowUndelegation()
+        .accounts({
+          counter: pda,
+          delegationRecord: delegationPda,
+          delegationMetadata: delegationMetadata,
+          buffer: bufferPda,
+          delegationProgram: DELEGATION_PROGRAM_ID,
+        }).transaction();
+
+    // Create the undelegation ix
+    const ixUndelegate = createUndelegateInstruction({
       payer: provider.wallet.publicKey,
       delegatedAccount: pda,
       ownerProgram: program.programId,
       reimbursement: provider.wallet.publicKey,
     });
-    let tx = new anchor.web3.Transaction().add(ix);
+    tx.add(ixUndelegate);
     tx.feePayer = provider.wallet.publicKey;
     tx.recentBlockhash = (
       await provider.connection.getLatestBlockhash()

--- a/anchor-counter/tests/anchor-counter.ts
+++ b/anchor-counter/tests/anchor-counter.ts
@@ -95,7 +95,7 @@ describe("anchor-counter", () => {
     tx.feePayer = provider.wallet.publicKey;
     tx.recentBlockhash = (await provider.connection.getLatestBlockhash()).blockhash;
     tx = await providerEphemeralRollup.wallet.signTransaction(tx);
-    const txSign = await provider.sendAndConfirm(tx, [],  {skipPreflight: true, commitment: "finalized"});
+    const txSign = await provider.sendAndConfirm(tx, [],  {skipPreflight: true, commitment: "confirmed"});
     console.log("Your transaction signature", txSign);
   });
 
@@ -156,6 +156,7 @@ describe("anchor-counter", () => {
       reimbursement: provider.wallet.publicKey,
     });
     tx.add(ixUndelegate);
+
     tx.feePayer = provider.wallet.publicKey;
     tx.recentBlockhash = (
       await provider.connection.getLatestBlockhash()

--- a/anchor-counter/yarn.lock
+++ b/anchor-counter/yarn.lock
@@ -37,10 +37,10 @@
     bn.js "^5.1.2"
     buffer-layout "^1.2.0"
 
-"@magicblock-labs/delegation-program@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@magicblock-labs/delegation-program/-/delegation-program-0.1.1.tgz#71a5fb25ccf88ea7746ea70473fb109ff6b67433"
-  integrity sha512-4He8V7jkrGy8MTp6qAz2h5y70+6y4cmvQc+7Km6B7WDLODlymPu9zZEl1/bmY24bOeKVKfrEEE7pDVa8qr3BwQ==
+"@magicblock-labs/delegation-program@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@magicblock-labs/delegation-program/-/delegation-program-0.1.2.tgz#7b298398259d80a368eb9e91cb911e5a6e542391"
+  integrity sha512-9EGtcBWGAXGCOjTJVyzxydMpM8GGk8QjzQlgpV0q96BAbmpEO9C6b/N3lvMRTR1FfDuBn43a3Pa5YEiHyUu8Eg==
   dependencies:
     "@metaplex-foundation/beet" "^0.7.2"
     "@solana/web3.js" "^1.92.3"


### PR DESCRIPTION
# Add allow undelegation through CPI

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature | Yes | - |

## Description

- Introduce a method to permit undelegation through CPI, aiming to avoid situations where undelegation should not occur until specific conditions are met.
- `delegate_account_seeds` has been renamed to `delegation_metadata`

Undelegation can be permitted through CPI by adding the following code to an instruction:

```rust
delegation_program_sdk::allow_undelegation(
    &ctx.accounts.counter,
    &ctx.accounts.delegation_record,
    &ctx.accounts.delegation_metadata,
    &ctx.accounts.buffer,
    &ctx.accounts.delegation_program,
    &id(),
)?;
```

Undelegation can be peformed in a single transaction, but combining the custom `allow_undelegation` and `undelegation` instruction.

```typescript
const { delegationPda, delegationMetadata, bufferPda, commitStateRecordPda, commitStatePda} = DelegateAccounts(pda, program.programId);
let tx = await program.methods
    .allowUndelegation()
    .accounts({
      counter: pda,
      delegationRecord: delegationPda,
      delegationMetadata: delegationMetadata,
      buffer: bufferPda,
      delegationProgram: DELEGATION_PROGRAM_ID,
    }).transaction();
tx.feePayer = provider.wallet.publicKey;
tx.recentBlockhash = (
  await provider.connection.getLatestBlockhash()
).blockhash;

// Create the undelegation ix
const ixUndelegate = createUndelegateInstruction({
  payer: provider.wallet.publicKey,
  delegatedAccount: pda,
  ownerProgram: program.programId,
  reimbursement: provider.wallet.publicKey,
});

// Add the undelegation ix to the tx
tx.add(ixUndelegate);

tx = await provider.wallet.signTransaction(tx);
const txSign = await provider.sendAndConfirm(tx, [], {skipPreflight: true});
console.log("Undelegate Tx: ", txSign);
```

### Notes

- This includes a breaking change in how the delegation_record PDA is parsed. Fields such as is_undelegatable and valid_until have been moved to an additional PDA, optimizing PDA cloning.
- Combing `allow_undelegation` and `undelegation` in a single transaction avoid the reentrancy issue of doing it in a single instruction: `counter -> delegation, delegation -> counter` vs `counter -> delegation -> counter`
- An additional method to do it in a single ix can be added in a future release, following `delegation -> hook to counter custom allow_undelegation -> counter`