### PR TITLE
docs: update rust-counter README and fix minor code typo

### DIFF
--- a/rust-counter/README.md
+++ b/rust-counter/README.md
@@ -31,10 +31,10 @@ cargo build-sbf
 solana program deploy target/deploy/rust_counter.so
 ````
 
-Add wallet (if not a new keypair will be generated) and RPC endpoints to the file example.env and update filename to .env:
+Add wallet (if not a new keypair will be generated) and RPC endpoints to the file `example.env` and update filename to `.env`:
 
 ```bash
-PRIVATE_KEY=
+PRIVATE_KEY=<YOUR-PRIVATE-KEY>
 ```
 
 Run the tests:

--- a/rust-counter/README.md
+++ b/rust-counter/README.md
@@ -4,7 +4,7 @@ Simple counter program using Rust Native and Ephemeral Rollups
 
 ## Software Packages
 
-This program has utilized the following sofware packages.
+This program has utilized the following software packages.
 
 | Software   | Version | Installation Guide                                      |
 | ---------- | ------- | ------------------------------------------------------- |
@@ -20,7 +20,7 @@ agave-install init 2.3.13
 # Check and initialize your Rust version
 rustup show
 rustup install 1.85.0
-
+````
 
 ## ✨ Build and Test
 

--- a/rust-counter/README.md
+++ b/rust-counter/README.md
@@ -20,7 +20,6 @@ agave-install init 2.3.13
 # Check and initialize your Rust version
 rustup show
 rustup install 1.85.0
-````
 
 ## ✨ Build and Test
 

--- a/rust-counter/tests/kit/rust-counter.test.ts
+++ b/rust-counter/tests/kit/rust-counter.test.ts
@@ -92,7 +92,7 @@ describe("basic-test", async () => {
   it(
     "Initialize counter on Solana",
     async () => {
-      const start = Date.now();``
+      const start = Date.now();
 
       // Prepare transaction
       const accounts = [


### PR DESCRIPTION
Updates the Rust Counter example documentation and fixes a minor syntax issue in the test file.

Changes include:
1. Removed stray backticks in test file (const start = Date.now();`` → `const start = Date.now();), which would have caused a syntax error if executed.

2. Added PRIVATE_KEY placeholder to `.env` example.

Before:
<img width="320" height="72" alt="image" src="https://github.com/user-attachments/assets/9bf37c5e-3ce5-4438-9ab0-9bcaa79f1163" />

After:
<img width="274" height="74" alt="image" src="https://github.com/user-attachments/assets/d909e18b-c9aa-4c38-b492-593e8badce52" />

3. Added backticks around `example.env` and `.env` for clarity.
4. Fixed typo in README ("sofware" → "software")





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed typos and improved formatting in setup instructions.
  * Enhanced code snippet visibility with improved markup.
  * Clarified private key placeholder in configuration guidance.

* **Tests**
  * Cleaned up formatting in test code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->