### PR TITLE
Fix Solana CLI version mismatch

### DIFF
--- a/anchor-rock-paper-scissor/README.md
+++ b/anchor-rock-paper-scissor/README.md
@@ -38,7 +38,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 2. Install Solana CLI:
 ```bash
-sh -c "$(curl -sSfL https://release.solana.com/v1.18.0/install)"
+sh -c "$(curl -sSfL https://release.solana.com/v2.3.13/install)"
 ```
 
 3. Install Anchor:

--- a/anchor-rock-paper-scissor/README.md
+++ b/anchor-rock-paper-scissor/README.md
@@ -38,7 +38,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 2. Install Solana CLI:
 ```bash
-sh -c "$(curl -sSfL https://release.solana.com/v2.3.13/install)"
+sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.13/install)"
 ```
 
 3. Install Anchor:


### PR DESCRIPTION
Fixed version inconsistency: documentation required Solana 2.3.13:
<img width="327" height="186" alt="image" src="https://github.com/user-attachments/assets/ef1bb684-c697-492d-9b49-fc163a2b4de5" />
but installation command was installing v1.18.0.

**Updated installation instructions to use the correct pinned Solana version (2.3.13).**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Solana CLI installation instructions in README to reflect the latest version requirements, ensuring developers follow current setup procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->