### PR TITLE
Pin Anchor version to 0.32.1 instead of using latest

### DIFF
--- a/anchor-rock-paper-scissor/README.md
+++ b/anchor-rock-paper-scissor/README.md
@@ -44,8 +44,8 @@ sh -c "$(curl -sSfL https://release.solana.com/v1.18.0/install)"
 3. Install Anchor:
 ```bash
 cargo install --git https://github.com/coral-xyz/anchor avm --locked --force
-avm install latest
-avm use latest
+avm install 0.32.1
+avm use 0.32.1
 ```
 
 4. Configure Solana (optional, for devnet):


### PR DESCRIPTION
Replaced `avm install latest` and `avm use latest` with the explicitly specified version `0.32.1`, which is mentioned at the beginning of the documentation:
<img width="329" height="185" alt="image" src="https://github.com/user-attachments/assets/693c030b-7dfc-4f5d-bad9-12ad7fb3d928" />

Updated the installation commands to match the declared Anchor version to avoid potential inconsistencies.

### Notes:

I’m not 100% sure this is the intended approach, so I decided to create this as a separate PR instead of combining it with the previous changes in the same file (see related PR: #64).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Anchor installation instructions to use version 0.32.1 instead of the latest version, ensuring consistent setup across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->