### PR TITLE
feat: update binary prediction token authority

### DIFF
--- a/binary-prediction/programs/binary-prediction/src/lib.rs
+++ b/binary-prediction/programs/binary-prediction/src/lib.rs
@@ -219,9 +219,16 @@ pub mod binary_prediction {
         let open_price = read_price(&ctx.accounts.price_update, &ctx.accounts.pool.price_feed_id)?;
         let now = Clock::get()?.unix_timestamp;
         let required_payout = checked_payout(stake, ctx.accounts.pool.payout_bps)?;
-        let pool_balance = ctx.accounts.pool_token_account.amount;
+        // Solvency is checked against the balance *after* the stake lands, since
+        // the stake is transferred into the pool below and backs the payout.
+        let available_after_stake = ctx
+            .accounts
+            .pool_token_account
+            .amount
+            .checked_add(stake)
+            .ok_or(ErrorCode::MathOverflow)?;
         require!(
-            pool_balance >= required_payout,
+            available_after_stake >= required_payout,
             ErrorCode::InsufficientLiquidity
         );
 
@@ -460,6 +467,7 @@ pub struct PlaceBet<'info> {
     pub user_token_account: Account<'info, TokenAccount>,
     #[account(
         mut,
+        constraint = pool_token_account.key() == associated_token_pda(&pool.key(), &pool.mint) @ ErrorCode::InvalidTokenOwner,
         constraint = pool_token_account.owner == pool.key() @ ErrorCode::InvalidTokenOwner,
         constraint = pool_token_account.mint == pool.mint @ ErrorCode::MintMismatch
     )]
@@ -490,6 +498,7 @@ pub struct Settle<'info> {
     pub user_token_account: Account<'info, TokenAccount>,
     #[account(
         mut,
+        constraint = pool_token_account.key() == associated_token_pda(&pool.key(), &pool.mint) @ ErrorCode::InvalidTokenOwner,
         constraint = pool_token_account.owner == pool.key() @ ErrorCode::InvalidTokenOwner,
         constraint = pool_token_account.mint == pool.mint @ ErrorCode::MintMismatch
     )]

--- a/binary-prediction/programs/binary-prediction/src/lib.rs
+++ b/binary-prediction/programs/binary-prediction/src/lib.rs
@@ -115,8 +115,9 @@ pub mod binary_prediction {
             &ctx.accounts.system_program,
             validator,
         )?;
+        let mint_key = ctx.accounts.mint.key();
         let pool_bump = [ctx.accounts.pool.bump];
-        let pool_seeds: &[&[u8]] = &[POOL_SEED, &pool_bump];
+        let pool_seeds: &[&[u8]] = &[POOL_SEED, mint_key.as_ref(), &pool_bump];
         transfer_to_vault(
             &ctx.accounts.ephemeral_token_program,
             &ctx.accounts.pool_ephemeral_ata,
@@ -277,6 +278,7 @@ pub mod binary_prediction {
                 ctx.accounts.pool.to_account_info(),
                 ctx.accounts.token_program.to_account_info(),
                 payout,
+                ctx.accounts.pool.mint,
                 ctx.accounts.pool.bump,
             )?;
         }
@@ -310,7 +312,7 @@ pub struct Initialize<'info> {
         init,
         payer = admin,
         space = 8 + Pool::LEN,
-        seeds = [POOL_SEED],
+        seeds = [POOL_SEED, mint.key().as_ref()],
         bump
     )]
     pub pool: Account<'info, Pool>,
@@ -445,7 +447,8 @@ pub struct PlaceBet<'info> {
     pub payer: Signer<'info>,
     /// CHECK: user authority for the bet and session token.
     pub user: UncheckedAccount<'info>,
-    #[account(seeds = [POOL_SEED], bump = pool.bump)]
+    pub mint: Account<'info, Mint>,
+    #[account(seeds = [POOL_SEED, mint.key().as_ref()], bump = pool.bump)]
     pub pool: Account<'info, Pool>,
     #[account(mut, seeds = [BET_SEED, user.key().as_ref()], bump)]
     pub bet: Account<'info, Bet>,
@@ -474,7 +477,8 @@ pub struct Settle<'info> {
     pub payer: Signer<'info>,
     /// CHECK: user authority for the bet.
     pub user: UncheckedAccount<'info>,
-    #[account(seeds = [POOL_SEED], bump = pool.bump)]
+    pub mint: Account<'info, Mint>,
+    #[account(seeds = [POOL_SEED, mint.key().as_ref()], bump = pool.bump)]
     pub pool: Account<'info, Pool>,
     #[account(mut, seeds = [BET_SEED, user.key().as_ref()], bump)]
     pub bet: Account<'info, Bet>,

--- a/binary-prediction/programs/binary-prediction/src/lib.rs
+++ b/binary-prediction/programs/binary-prediction/src/lib.rs
@@ -36,8 +36,8 @@ pub mod binary_prediction {
     use super::*;
 
     /// Creates the prediction pool and moves its starting liquidity into ER custody.
-    /// The Pool PDA stores market config on the base layer, while the pool
-    /// authority's token account is deposited into an EATA and delegated to the ER.
+    /// The Pool PDA stores market config and owns the pool token account that is
+    /// deposited into an EATA and delegated to the ER.
     pub fn initialize(
         ctx: Context<Initialize>,
         price_feed: Pubkey,
@@ -55,9 +55,10 @@ pub mod binary_prediction {
             ErrorCode::InvalidPoolConfig
         );
 
+        let pool_key = ctx.accounts.pool.key();
         let pool = &mut ctx.accounts.pool;
         pool.mint = ctx.accounts.mint.key();
-        pool.authority = ctx.accounts.pool_authority.key();
+        pool.authority = pool_key;
         pool.price_feed = price_feed;
         pool.price_feed_id = price_feed_id;
         pool.bet_duration_seconds = bet_duration_seconds;
@@ -78,7 +79,7 @@ pub mod binary_prediction {
         init_ephemeral_ata(
             &ctx.accounts.ephemeral_token_program,
             &ctx.accounts.pool_ephemeral_ata,
-            ctx.accounts.pool_authority.to_account_info(),
+            ctx.accounts.pool.to_account_info(),
             &ctx.accounts.mint,
             &ctx.accounts.admin,
             &ctx.accounts.system_program,
@@ -114,6 +115,8 @@ pub mod binary_prediction {
             &ctx.accounts.system_program,
             validator,
         )?;
+        let pool_bump = [ctx.accounts.pool.bump];
+        let pool_seeds: &[&[u8]] = &[POOL_SEED, &pool_bump];
         transfer_to_vault(
             &ctx.accounts.ephemeral_token_program,
             &ctx.accounts.pool_ephemeral_ata,
@@ -121,10 +124,10 @@ pub mod binary_prediction {
             &ctx.accounts.mint,
             &ctx.accounts.pool_token_account,
             &ctx.accounts.vault_token_account,
-            ctx.accounts.pool_authority.to_account_info(),
+            ctx.accounts.pool.to_account_info(),
             &ctx.accounts.token_program,
             seed_amount,
-            None,
+            Some(pool_seeds),
         )?;
         delegate_ephemeral_ata(
             &ctx.accounts.ephemeral_token_program,
@@ -185,8 +188,9 @@ pub mod binary_prediction {
     }
 
     /// Opens one UP or DOWN prediction on the ER.
-    /// The Pool PDA spends from the user's delegated token allowance, records the
-    /// current oracle price, and sets the earliest settlement time.
+    /// The payer spends from the user's token account as either the user signer
+    /// or an approved session delegate, records the current oracle price, and
+    /// sets the earliest settlement time.
     #[session_auth_or(
         ctx.accounts.user.key() == ctx.accounts.payer.key(),
         SessionError::InvalidToken
@@ -203,26 +207,29 @@ pub mod binary_prediction {
             ErrorCode::InvalidPriceFeed
         );
 
-        let pool_key = ctx.accounts.pool.key();
-        require_token_delegate(&ctx.accounts.user_token_account, pool_key, stake)?;
+        if ctx.accounts.payer.key() != ctx.accounts.user.key() {
+            require_token_delegate(
+                &ctx.accounts.user_token_account,
+                ctx.accounts.payer.key(),
+                stake,
+            )?;
+        }
 
         let open_price = read_price(&ctx.accounts.price_update, &ctx.accounts.pool.price_feed_id)?;
         let now = Clock::get()?.unix_timestamp;
         let required_payout = checked_payout(stake, ctx.accounts.pool.payout_bps)?;
-        require_token_delegate(&ctx.accounts.pool_token_account, pool_key, required_payout)?;
         let pool_balance = ctx.accounts.pool_token_account.amount;
         require!(
             pool_balance >= required_payout,
             ErrorCode::InsufficientLiquidity
         );
 
-        pool_signed_transfer(
+        signer_transfer(
             ctx.accounts.user_token_account.to_account_info(),
             ctx.accounts.pool_token_account.to_account_info(),
-            ctx.accounts.pool.to_account_info(),
+            ctx.accounts.payer.to_account_info(),
             ctx.accounts.token_program.to_account_info(),
             stake,
-            ctx.accounts.pool.bump,
         )?;
 
         let bet = &mut ctx.accounts.bet;
@@ -264,11 +271,6 @@ pub mod binary_prediction {
         };
 
         if payout > 0 {
-            require_token_delegate(
-                &ctx.accounts.pool_token_account,
-                ctx.accounts.pool.key(),
-                payout,
-            )?;
             pool_signed_transfer(
                 ctx.accounts.pool_token_account.to_account_info(),
                 ctx.accounts.user_token_account.to_account_info(),
@@ -290,8 +292,7 @@ pub mod binary_prediction {
 }
 
 /// Accounts for pool creation and one-time liquidity delegation.
-/// Notice that the Pool PDA itself is not delegated; only the pool authority's
-/// token EATA is delegated to the ER.
+/// The Pool PDA owns the pool token account and its EATA is delegated to the ER.
 #[derive(Accounts)]
 #[instruction(
     price_feed: Pubkey,
@@ -317,10 +318,9 @@ pub struct Initialize<'info> {
         init_if_needed,
         payer = admin,
         associated_token::mint = mint,
-        associated_token::authority = pool_authority
+        associated_token::authority = pool
     )]
     pub pool_token_account: Account<'info, TokenAccount>,
-    pub pool_authority: Signer<'info>,
     #[account(
         mut,
         constraint = admin_token_account.owner == admin.key() @ ErrorCode::InvalidTokenOwner,
@@ -329,7 +329,7 @@ pub struct Initialize<'info> {
     pub admin_token_account: Account<'info, TokenAccount>,
     #[account(
         mut,
-        constraint = pool_ephemeral_ata.key() == ephemeral_ata_pda(&pool_authority.key(), &mint.key()) @ ErrorCode::InvalidEphemeralAta
+        constraint = pool_ephemeral_ata.key() == ephemeral_ata_pda(&pool.key(), &mint.key()) @ ErrorCode::InvalidEphemeralAta
     )]
     /// CHECK: created and delegated by the Ephemeral SPL Token program.
     pub pool_ephemeral_ata: UncheckedAccount<'info>,
@@ -439,7 +439,7 @@ pub struct UndelegateBet<'info> {
 }
 
 /// Accounts for opening a prediction on the ER.
-/// The token accounts must already be delegated to the Pool PDA by the client.
+/// A session payer must be approved as delegate for the user's token account.
 #[derive(Accounts, Session)]
 pub struct PlaceBet<'info> {
     pub payer: Signer<'info>,
@@ -457,7 +457,7 @@ pub struct PlaceBet<'info> {
     pub user_token_account: Account<'info, TokenAccount>,
     #[account(
         mut,
-        constraint = pool_token_account.owner == pool.authority @ ErrorCode::InvalidTokenOwner,
+        constraint = pool_token_account.owner == pool.key() @ ErrorCode::InvalidTokenOwner,
         constraint = pool_token_account.mint == pool.mint @ ErrorCode::MintMismatch
     )]
     pub pool_token_account: Account<'info, TokenAccount>,
@@ -486,7 +486,7 @@ pub struct Settle<'info> {
     pub user_token_account: Account<'info, TokenAccount>,
     #[account(
         mut,
-        constraint = pool_token_account.owner == pool.authority @ ErrorCode::InvalidTokenOwner,
+        constraint = pool_token_account.owner == pool.key() @ ErrorCode::InvalidTokenOwner,
         constraint = pool_token_account.mint == pool.mint @ ErrorCode::MintMismatch
     )]
     pub pool_token_account: Account<'info, TokenAccount>,

--- a/binary-prediction/programs/binary-prediction/src/state.rs
+++ b/binary-prediction/programs/binary-prediction/src/state.rs
@@ -1,12 +1,11 @@
 use anchor_lang::prelude::*;
 
 /// Pool configuration for this prediction market.
-/// The Pool PDA signs token transfers, but the actual pool tokens are owned by
-/// `authority` and kept in a delegated EATA on the ER.
+/// The Pool PDA owns pool token custody and signs payout transfers.
 #[account]
 pub struct Pool {
     pub mint: Pubkey,
-    /// Real signer that owns the pool token custody.
+    /// Pool token authority. This is the Pool PDA itself.
     pub authority: Pubkey,
     /// Oracle account accepted by betting and settlement instructions.
     pub price_feed: Pubkey,

--- a/binary-prediction/programs/binary-prediction/src/utils.rs
+++ b/binary-prediction/programs/binary-prediction/src/utils.rs
@@ -79,10 +79,11 @@ pub(crate) fn pool_signed_transfer<'info>(
     pool: AccountInfo<'info>,
     token_program: AccountInfo<'info>,
     amount: u64,
+    pool_mint: Pubkey,
     pool_bump: u8,
 ) -> Result<()> {
     let pool_bump_seed = [pool_bump];
-    let signer_seeds: &[&[&[u8]]] = &[&[POOL_SEED, &pool_bump_seed]];
+    let signer_seeds: &[&[&[u8]]] = &[&[POOL_SEED, pool_mint.as_ref(), &pool_bump_seed]];
     let cpi_accounts = SplTransfer {
         from,
         to,

--- a/binary-prediction/programs/binary-prediction/src/utils.rs
+++ b/binary-prediction/programs/binary-prediction/src/utils.rs
@@ -72,9 +72,7 @@ pub(crate) fn outcome(settle_price: i64, open_price: i64) -> Result<Direction> {
     }
 }
 
-/// Transfers tokens using the Pool PDA as the SPL delegate authority.
-/// The user and pool token accounts approve this PDA so ER instructions can move
-/// stake and payouts without requiring another wallet signature.
+/// Transfers tokens using the Pool PDA as SPL token authority.
 pub(crate) fn pool_signed_transfer<'info>(
     from: AccountInfo<'info>,
     to: AccountInfo<'info>,
@@ -91,6 +89,24 @@ pub(crate) fn pool_signed_transfer<'info>(
         authority: pool,
     };
     let cpi_ctx = CpiContext::new_with_signer(token_program.key(), cpi_accounts, signer_seeds);
+    token::transfer(cpi_ctx, amount)?;
+    Ok(())
+}
+
+/// Transfers tokens using the transaction signer as SPL owner or delegate.
+pub(crate) fn signer_transfer<'info>(
+    from: AccountInfo<'info>,
+    to: AccountInfo<'info>,
+    authority: AccountInfo<'info>,
+    token_program: AccountInfo<'info>,
+    amount: u64,
+) -> Result<()> {
+    let cpi_accounts = SplTransfer {
+        from,
+        to,
+        authority,
+    };
+    let cpi_ctx = CpiContext::new(token_program.key(), cpi_accounts);
     token::transfer(cpi_ctx, amount)?;
     Ok(())
 }

--- a/binary-prediction/tests/binary-prediction.ts
+++ b/binary-prediction/tests/binary-prediction.ts
@@ -247,6 +247,39 @@ async function sleep(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+async function sendLocalTransaction(
+  connection: web3.Connection,
+  transaction: web3.Transaction,
+  feePayer: web3.Keypair,
+  signers: web3.Keypair[] = [],
+): Promise<string> {
+  const blockhash = await connection.getLatestBlockhash("confirmed");
+  const signerMap = new Map<string, web3.Keypair>();
+  [feePayer, ...signers].forEach((signer) =>
+    signerMap.set(signer.publicKey.toBase58(), signer),
+  );
+
+  transaction.feePayer = feePayer.publicKey;
+  transaction.recentBlockhash = blockhash.blockhash;
+  transaction.partialSign(...signerMap.values());
+
+  const signature = await connection.sendRawTransaction(
+    transaction.serialize(),
+    { skipPreflight: true },
+  );
+  const status = await connection.confirmTransaction(
+    { signature, ...blockhash },
+    "confirmed",
+  );
+  if (status.value.err) {
+    throw new Error(
+      `Transaction ${signature} failed: ${JSON.stringify(status.value.err)}`,
+    );
+  }
+
+  return signature;
+}
+
 function findLogValue(logMessages: string[], prefix: string): string | null {
   const message = logMessages.find((log) => log.includes(prefix));
 
@@ -344,7 +377,6 @@ describe("binary-prediction", () => {
 
   const admin = (provider.wallet as anchor.Wallet).payer;
   const user = web3.Keypair.generate();
-  const poolAuthority = web3.Keypair.generate();
   const sessionKeypair = web3.Keypair.generate();
   const feed = priceFeed();
   const feedId = Array.from(feed.toBytes());
@@ -377,19 +409,8 @@ describe("binary-prediction", () => {
       mint,
       user.publicKey,
     );
-    await provider.sendAndConfirm(
-      new anchor.web3.Transaction().add(
-        web3.SystemProgram.transfer({
-          fromPubkey: admin.publicKey,
-          toPubkey: poolAuthority.publicKey,
-          lamports: web3.LAMPORTS_PER_SOL,
-        }),
-      ),
-      [admin],
-      { commitment: "confirmed", skipPreflight: true },
-    );
-    poolAta = getAssociatedTokenAddressSync(mint, poolAuthority.publicKey);
-    poolEata = eata(poolAuthority.publicKey, mint);
+    poolAta = getAssociatedTokenAddressSync(mint, pool, true);
+    poolEata = eata(pool, mint);
     vaultPda = vault(mint);
     vaultEata = eata(vaultPda, mint);
     vaultAta = getAssociatedTokenAddressSync(mint, vaultPda, true);
@@ -410,27 +431,36 @@ describe("binary-prediction", () => {
       BigInt(POOL_SEED_AMOUNT.toString()),
     );
 
-    await provider.sendAndConfirm(
-      new anchor.web3.Transaction().add(
-        initializePriceFeedIx(admin.publicKey, feed),
-      ),
-      [admin],
-      { commitment: "confirmed", skipPreflight: true },
+    const feedAccount = await provider.connection.getAccountInfo(
+      feed,
+      "confirmed",
     );
+    const feedIsDelegated = Boolean(
+      feedAccount?.owner.equals(DELEGATION_PROGRAM_ID),
+    );
+    if (!feedAccount) {
+      await sendLocalTransaction(
+        provider.connection,
+        new anchor.web3.Transaction().add(
+          initializePriceFeedIx(admin.publicKey, feed),
+        ),
+        admin,
+      );
+    }
 
-    await provider.sendAndConfirm(
+    await sendLocalTransaction(
+      feedIsDelegated ? erProvider.connection : provider.connection,
       new anchor.web3.Transaction().add(
         updatePriceFeedIx(admin.publicKey, feed, 100),
       ),
-      [admin],
-      { commitment: "confirmed", skipPreflight: true },
+      admin,
     );
 
     const validator = new web3.PublicKey(
       process.env.VALIDATOR ?? "mAGicPQYBMvcYveUZA5F5UNNwyHvfYh5xkLS2Fr1mev",
     );
 
-    await program.methods
+    const initializeTx = await program.methods
       .initialize(
         feed,
         feedId,
@@ -447,7 +477,6 @@ describe("binary-prediction", () => {
         mint,
         pool,
         poolTokenAccount: poolAta,
-        poolAuthority: poolAuthority.publicKey,
         adminTokenAccount: adminAta,
         poolEphemeralAta: poolEata,
         vault: vaultPda,
@@ -474,8 +503,8 @@ describe("binary-prediction", () => {
       .remainingAccounts([
         { pubkey: validator, isSigner: false, isWritable: false },
       ])
-      .signers([admin, poolAuthority])
-      .rpc({ skipPreflight: true });
+      .transaction();
+    await sendLocalTransaction(provider.connection, initializeTx, admin);
 
     const poolState = await program.account.pool.fetch(pool);
     expect(poolState.betDurationSeconds.toNumber()).to.equal(
@@ -490,7 +519,7 @@ describe("binary-prediction", () => {
       0n,
     );
 
-    await program.methods
+    const initializeBetTx = await program.methods
       .initializeBet()
       .accountsPartial({
         payer: admin.publicKey,
@@ -498,18 +527,20 @@ describe("binary-prediction", () => {
         bet: userBet,
         systemProgram: web3.SystemProgram.programId,
       })
-      .signers([admin])
-      .rpc({ skipPreflight: false });
+      .transaction();
+    await sendLocalTransaction(provider.connection, initializeBetTx, admin);
 
-    await provider.sendAndConfirm(
-      new anchor.web3.Transaction().add(
-        delegatePriceFeedIx(admin.publicKey, feed),
-      ),
-      [admin],
-      { commitment: "confirmed", skipPreflight: true },
-    );
+    if (!feedIsDelegated) {
+      await sendLocalTransaction(
+        provider.connection,
+        new anchor.web3.Transaction().add(
+          delegatePriceFeedIx(admin.publicKey, feed),
+        ),
+        admin,
+      );
+    }
 
-    await program.methods
+    const delegateBetTx = await program.methods
       .delegateBet()
       .accountsPartial({
         payer: admin.publicKey,
@@ -519,8 +550,10 @@ describe("binary-prediction", () => {
       .remainingAccounts([
         { pubkey: validator, isSigner: false, isWritable: false },
       ])
-      .signers([admin, user])
-      .rpc({ skipPreflight: true });
+      .transaction();
+    await sendLocalTransaction(provider.connection, delegateBetTx, admin, [
+      user,
+    ]);
 
     const delegateUserIxs = await delegateSpl(
       user.publicKey,
@@ -533,13 +566,64 @@ describe("binary-prediction", () => {
         payer: admin.publicKey,
       },
     );
-    await provider.sendAndConfirm(
+    await sendLocalTransaction(
+      provider.connection,
       new anchor.web3.Transaction().add(...delegateUserIxs),
-      [user, admin],
-      { commitment: "confirmed", skipPreflight: true },
+      admin,
+      [user],
     );
 
     await sleep(3_000);
+
+    const placeWalletBetTx = await erProgram.methods
+      .placeBet({ up: {} }, STAKE)
+      .accountsPartial({
+        payer: user.publicKey,
+        user: user.publicKey,
+        pool,
+        bet: userBet,
+        userTokenAccount: userAta,
+        poolTokenAccount: poolAta,
+        priceUpdate: feed,
+        tokenProgram: TOKEN_PROGRAM_ID,
+        sessionToken: null,
+      })
+      .transaction();
+    await sendLocalTransaction(erProvider.connection, placeWalletBetTx, admin, [
+      user,
+    ]);
+
+    let bet = await erProgram.account.bet.fetch(userBet);
+    expect(bet.openPrice.toNumber()).to.equal(100);
+    expect(bet.stake.toNumber()).to.equal(STAKE.toNumber());
+    expect(bet.isOpen).to.equal(true);
+
+    await sendLocalTransaction(
+      erProvider.connection,
+      new anchor.web3.Transaction().add(
+        updatePriceFeedIx(admin.publicKey, feed, 110),
+      ),
+      admin,
+    );
+    await sleep(BET_DURATION_MS);
+
+    const settleWinTx = await erProgram.methods
+      .settle()
+      .accountsPartial({
+        payer: admin.publicKey,
+        user: user.publicKey,
+        pool,
+        bet: userBet,
+        userTokenAccount: userAta,
+        poolTokenAccount: poolAta,
+        priceUpdate: feed,
+        tokenProgram: TOKEN_PROGRAM_ID,
+      })
+      .transaction();
+    await sendLocalTransaction(erProvider.connection, settleWinTx, admin);
+
+    bet = await erProgram.account.bet.fetch(userBet);
+    expect(bet.isOpen).to.equal(false);
 
     const sessionTokenManager = new SessionTokenManager(
       provider.wallet,
@@ -554,7 +638,7 @@ describe("binary-prediction", () => {
       ],
       sessionTokenManager.program.programId,
     )[0];
-    await sessionTokenManager.program.methods
+    const createSessionTx = await sessionTokenManager.program.methods
       .createSessionV2(
         true,
         new BN(Math.floor(Date.now() / 1000) + 3600),
@@ -566,77 +650,27 @@ describe("binary-prediction", () => {
         feePayer: admin.publicKey,
         authority: user.publicKey,
       })
-      .signers([admin, user, sessionKeypair])
-      .rpc({ skipPreflight: true });
+      .transaction();
+    await sendLocalTransaction(provider.connection, createSessionTx, admin, [
+      user,
+      sessionKeypair,
+    ]);
 
-    await erProvider.sendAndConfirm(
+    await sendLocalTransaction(
+      erProvider.connection,
       new anchor.web3.Transaction().add(
-        createApproveInstruction(
-          poolAta,
-          pool,
-          poolAuthority.publicKey,
-          BigInt(POOL_SEED_AMOUNT.toString()),
-        ),
         createApproveInstruction(
           userAta,
-          pool,
+          sessionKeypair.publicKey,
           user.publicKey,
-          2n * BigInt(STAKE.toString()),
+          BigInt(STAKE.toString()),
         ),
       ),
-      [admin, poolAuthority, user],
-      { commitment: "confirmed", skipPreflight: true },
+      admin,
+      [user],
     );
 
-    await erProgram.methods
-      .placeBet({ up: {} }, STAKE)
-      .accountsPartial({
-        payer: sessionKeypair.publicKey,
-        user: user.publicKey,
-        pool,
-        bet: userBet,
-        userTokenAccount: userAta,
-        poolTokenAccount: poolAta,
-        priceUpdate: feed,
-        tokenProgram: TOKEN_PROGRAM_ID,
-        sessionToken: sessionTokenPda,
-      })
-      .signers([sessionKeypair])
-      .rpc({ skipPreflight: true });
-
-    let bet = await erProgram.account.bet.fetch(userBet);
-    expect(bet.openPrice.toNumber()).to.equal(100);
-    expect(bet.stake.toNumber()).to.equal(STAKE.toNumber());
-    expect(bet.isOpen).to.equal(true);
-
-    await erProvider.sendAndConfirm(
-      new anchor.web3.Transaction().add(
-        updatePriceFeedIx(admin.publicKey, feed, 110),
-      ),
-      [admin],
-      { commitment: "confirmed", skipPreflight: true },
-    );
-    await sleep(BET_DURATION_MS);
-
-    await erProgram.methods
-      .settle()
-      .accountsPartial({
-        payer: admin.publicKey,
-        user: user.publicKey,
-        pool,
-        bet: userBet,
-        userTokenAccount: userAta,
-        poolTokenAccount: poolAta,
-        priceUpdate: feed,
-        tokenProgram: TOKEN_PROGRAM_ID,
-      })
-      .signers([admin])
-      .rpc({ skipPreflight: true });
-
-    bet = await erProgram.account.bet.fetch(userBet);
-    expect(bet.isOpen).to.equal(false);
-
-    await erProgram.methods
+    const placeSessionBetTx = await erProgram.methods
       .placeBet({ down: {} }, STAKE)
       .accountsPartial({
         payer: sessionKeypair.publicKey,
@@ -649,19 +683,24 @@ describe("binary-prediction", () => {
         tokenProgram: TOKEN_PROGRAM_ID,
         sessionToken: sessionTokenPda,
       })
-      .signers([sessionKeypair])
-      .rpc({ skipPreflight: true });
+      .transaction();
+    await sendLocalTransaction(
+      erProvider.connection,
+      placeSessionBetTx,
+      admin,
+      [sessionKeypair],
+    );
 
-    await erProvider.sendAndConfirm(
+    await sendLocalTransaction(
+      erProvider.connection,
       new anchor.web3.Transaction().add(
         updatePriceFeedIx(admin.publicKey, feed, 120),
       ),
-      [admin],
-      { commitment: "confirmed", skipPreflight: true },
+      admin,
     );
     await sleep(BET_DURATION_MS);
 
-    await erProgram.methods
+    const settleLossTx = await erProgram.methods
       .settle()
       .accountsPartial({
         payer: admin.publicKey,
@@ -673,8 +712,8 @@ describe("binary-prediction", () => {
         priceUpdate: feed,
         tokenProgram: TOKEN_PROGRAM_ID,
       })
-      .signers([admin])
-      .rpc({ skipPreflight: true });
+      .transaction();
+    await sendLocalTransaction(erProvider.connection, settleLossTx, admin);
 
     const erUserBalance = (await getAccount(erProvider.connection, userAta))
       .amount;
@@ -683,10 +722,10 @@ describe("binary-prediction", () => {
     expect(erUserBalance).to.equal(290n);
     expect(erPoolBalance).to.equal(10_010n);
 
-    const userUndelegateSig = await erProvider.sendAndConfirm(
+    const userUndelegateSig = await sendLocalTransaction(
+      erProvider.connection,
       new anchor.web3.Transaction().add(undelegateIx(user.publicKey, mint)),
-      [user],
-      { commitment: "confirmed", skipPreflight: true },
+      user,
     );
 
     await provider.connection.confirmTransaction(
@@ -706,10 +745,11 @@ describe("binary-prediction", () => {
         idempotent: false,
       },
     );
-    await provider.sendAndConfirm(
+    await sendLocalTransaction(
+      provider.connection,
       new anchor.web3.Transaction().add(...userWithdrawIxs),
+      admin,
       [user],
-      { commitment: "confirmed", skipPreflight: true },
     );
 
     expect((await getAccount(provider.connection, userAta)).amount).to.equal(

--- a/binary-prediction/tests/binary-prediction.ts
+++ b/binary-prediction/tests/binary-prediction.ts
@@ -380,12 +380,9 @@ describe("binary-prediction", () => {
   const sessionKeypair = web3.Keypair.generate();
   const feed = priceFeed();
   const feedId = Array.from(feed.toBytes());
-  const [pool] = web3.PublicKey.findProgramAddressSync(
-    [POOL_SEED],
-    program.programId,
-  );
   const userBet = betPda(program.programId, user.publicKey);
 
+  let pool: web3.PublicKey;
   let mint: web3.PublicKey;
   let userAta: web3.PublicKey;
   let poolAta: web3.PublicKey;
@@ -409,6 +406,10 @@ describe("binary-prediction", () => {
       mint,
       user.publicKey,
     );
+    pool = web3.PublicKey.findProgramAddressSync(
+      [POOL_SEED, mint.toBuffer()],
+      program.programId,
+    )[0];
     poolAta = getAssociatedTokenAddressSync(mint, pool, true);
     poolEata = eata(pool, mint);
     vaultPda = vault(mint);
@@ -580,6 +581,7 @@ describe("binary-prediction", () => {
       .accountsPartial({
         payer: user.publicKey,
         user: user.publicKey,
+        mint,
         pool,
         bet: userBet,
         userTokenAccount: userAta,
@@ -612,6 +614,7 @@ describe("binary-prediction", () => {
       .accountsPartial({
         payer: admin.publicKey,
         user: user.publicKey,
+        mint,
         pool,
         bet: userBet,
         userTokenAccount: userAta,
@@ -675,6 +678,7 @@ describe("binary-prediction", () => {
       .accountsPartial({
         payer: sessionKeypair.publicKey,
         user: user.publicKey,
+        mint,
         pool,
         bet: userBet,
         userTokenAccount: userAta,
@@ -705,6 +709,7 @@ describe("binary-prediction", () => {
       .accountsPartial({
         payer: admin.publicKey,
         user: user.publicKey,
+        mint,
         pool,
         bet: userBet,
         userTokenAccount: userAta,


### PR DESCRIPTION
## Summary

- Updates binary prediction token custody so the pool token account is owned by the Pool PDA.
- Removes the need for pool-token approval before settlement payouts.
- Updates `place_bet` so wallet bets transfer stake with the user signer, while session bets require the session signer to be approved as the user token delegate.
- Covers both wallet and session betting flows in the integration test.

## Testing

- `anchor build`
- `yarn lint:fix && yarn lint`
- `yarn test:local`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Betting and settlement now work with a pool that is derived from the selected token mint, improving support for mint-specific pools.
  * Session-based betting flow now supports direct signer transfers when the bettor and fee payer are the same.

* **Bug Fixes**
  * Improved payout handling so winners, ties, and losses follow the expected transfer path.
  * Reduced unnecessary token delegation requirements in betting and settlement flows, making transactions more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->