### PR TITLE
fix: accept the ephemeral oracle discriminator for the price feed

### DIFF
--- a/binary-prediction/app/src/lib/binaryPrediction.ts
+++ b/binary-prediction/app/src/lib/binaryPrediction.ts
@@ -275,20 +275,24 @@ function formatOraclePrice(raw: bigint, exponent: number) {
   return `${whole}.${fraction}`.replace(/\.?0+$/, "");
 }
 
-// Anchor account discriminator for pyth_solana_receiver_sdk's PriceUpdateV2
-// (first 8 bytes of sha256("account:PriceUpdateV2")). Validating it before
-// reading fixed offsets makes a wrong/renamed account fail clearly instead of
-// silently decoding garbage into the UI.
-const PRICE_UPDATE_V2_DISCRIMINATOR = Buffer.from([
-  34, 241, 35, 99, 157, 126, 244, 205,
-]);
+// Accepted 8-byte account discriminators for the SOL/USD price feed. Both
+// accounts share the PriceUpdateV2 field layout read below; validating the
+// discriminator makes a wrong/corrupt account fail clearly instead of silently
+// decoding garbage into the UI. The demo reads MagicBlock's ephemeral oracle
+// (its own discriminator), but the canonical Pyth PriceUpdateV2 discriminator
+// (sha256("account:PriceUpdateV2")) is accepted too so a real Pyth feed works.
+const PRICE_UPDATE_DISCRIMINATORS = [
+  Buffer.from([234, 161, 14, 36, 172, 239, 15, 232]), // ephemeral oracle
+  Buffer.from([34, 241, 35, 99, 157, 126, 244, 205]), // Pyth PriceUpdateV2
+];
 
 export function decodeOraclePrice(data: Buffer): OraclePrice {
   if (data.length < 133) {
     throw new Error("Oracle price account has invalid data");
   }
-  if (!data.subarray(0, 8).equals(PRICE_UPDATE_V2_DISCRIMINATOR)) {
-    throw new Error("Oracle account is not a Pyth PriceUpdateV2 account");
+  const discriminator = data.subarray(0, 8);
+  if (!PRICE_UPDATE_DISCRIMINATORS.some((d) => discriminator.equals(d))) {
+    throw new Error("Oracle account is not a recognized price-update account");
   }
 
   // PriceUpdateV2 fields from pyth_solana_receiver_sdk, after the discriminator.


### PR DESCRIPTION
## What

`decodeOraclePrice` validates the price-feed account's 8-byte discriminator before reading `PriceUpdateV2` fields at fixed offsets. It only accepted the canonical Pyth `PriceUpdateV2` discriminator (`sha256("account:PriceUpdateV2")`), but the SOL/USD feed the demo reads (`ENYwebBThHzmzwPLAQvCucUTsjyfBSZdD9ViXksS4jPu`) is served by MagicBlock's **ephemeral oracle** (owner `PriCems5tHihc6UDXDjzjeawomAwBduWMGAi8ZUjppd`), which mirrors the `PriceUpdateV2` field layout but uses its **own** discriminator. So every price read threw `Oracle account is not a Pyth PriceUpdateV2 account`, breaking the live price display and the whole flow.

## Why

The discriminator validation was added in #111 (a CodeRabbit suggestion) assuming a canonical Pyth account. This is a regression from that PR.

## Fix

Accept the ephemeral oracle's discriminator (`[234, 161, 14, 36, 172, 239, 15, 232]`) in addition to the canonical Pyth `PriceUpdateV2` one, so both a local/devnet ephemeral oracle and a real Pyth feed decode. Still fails clearly on an unrecognized account.

## Testing

- `tsc --noEmit` and `vite build` pass.
- Ran the production build locally against devnet: the live SOL/USD price now renders instead of erroring (verified the feed account's on-chain discriminator matches the accepted value).