### PR TITLE
fix: preload example fixtures from the project dir, not the project name

### DIFF
--- a/scripts/test-locally.sh
+++ b/scripts/test-locally.sh
@@ -612,25 +612,25 @@ if [ "${#BUILD_PROJECTS[@]}" -gt 0 ]; then
         echo "  WARNING: $so has no matching keypair ($(basename "$kp")); not preloaded."
       fi
     done
-    if [ -f "$p/Anchor.toml" ]; then
+    if [ -f "$dir/Anchor.toml" ]; then
       while IFS=$'\t' read -r address program upgradeable; do
         [ -n "$address" ] || continue
         case "$address" in
           SPLxh1LVZzEkX99H6rqYizhytLWPZVV296zyYDPagv2|DELeGGvXpWV2fqJUhqcF5ZSYMS4JTLjteaAMARRSaeSh)
-            echo "  $p/$program -> $address (built into mb-test-validator; skipping fixture preload)"
+            echo "  $dir/$program -> $address (built into mb-test-validator; skipping fixture preload)"
             continue
             ;;
         esac
-        fixture="$p/$program"
+        fixture="$dir/$program"
         if [ ! -f "$fixture" ]; then
-          echo "  WARNING: $p Anchor.toml fixture $program not found; not preloaded."
+          echo "  WARNING: $dir Anchor.toml fixture $program not found; not preloaded."
           continue
         fi
         if [ "$upgradeable" = "true" ]; then
-          echo "  $p/$program -> $address (upgradeable genesis fixture)"
+          echo "  $dir/$program -> $address (upgradeable genesis fixture)"
           PRELOAD_ARGS+=(--upgradeable-program "$address" "$fixture" "$WALLET_PUBKEY")
         else
-          echo "  $p/$program -> $address (genesis fixture)"
+          echo "  $dir/$program -> $address (genesis fixture)"
           PRELOAD_ARGS+=(--bpf-program "$address" "$fixture")
         fi
       done < <(awk '
@@ -674,9 +674,9 @@ if [ "${#BUILD_PROJECTS[@]}" -gt 0 ]; then
         END {
           if (in_genesis && address != "" && program != "") print address "\t" program "\t" upgradeable
         }
-      ' "$p/Anchor.toml")
+      ' "$dir/Anchor.toml")
     fi
-    for account in "$p"/tests/fixtures/accounts/*.json; do
+    for account in "$dir"/tests/fixtures/accounts/*.json; do
       [ -e "$account" ] || continue
       echo "  $account"
       PRELOAD_ARGS+=(--account - "$account")


### PR DESCRIPTION
## What

`scripts/test-locally.sh` preloads each example's genesis program fixtures and account fixtures into the `mb-test-validator`. It resolves the program `.so` from `\$dir` (`project_dir` → e.g. `binary-prediction/anchor`), but the Anchor.toml, genesis fixtures, and account fixtures were still resolved from `\$p` (the project **name**, e.g. `binary-prediction`).

## Why it broke

Before the framework grouping, `\$p == \$dir` (the example's directory *was* its name), so both worked. #108 moved `binary-prediction` → `binary-prediction/anchor` and `oracle-priced-purchase` → `oracle-priced-purchase/anchor`, so `\$p` and `\$dir` diverged. `\$p/Anchor.toml` no longer exists, so:

- the `[[test.genesis]]` preload block was skipped → the **ephemeral oracle** program (`PriCems…`) was never loaded → `binary-prediction` failed at `initializePriceFeedIx` with `"ProgramAccountNotFound"`.
- `\$p/tests/fixtures/accounts/*.json` didn't exist → `oracle-priced-purchase`'s **oracle price accounts** (`sol-usd-*.json`) weren't preloaded.

Only these two examples were affected because they're the only ones with genesis/account fixtures. This is a regression from #108.

## Fix

Use `\$dir` (the mapped project directory) for the Anchor.toml, genesis fixtures, and account fixtures — matching how the program `.so` is already resolved. Four `\$p` → `\$dir` replacements (lines ~615, 624, 677, 679) plus the cosmetic echo lines.

## Testing

Ran the local harness against both examples on a clean checkout:
- `scripts/test-example.sh binary-prediction` → **1 passed** (`ephemeral_oracle.so -> PriCems… (genesis fixture)` now preloads)
- `scripts/test-example.sh oracle-priced-purchase` → **1 passed** (`sol-usd-*.json` account fixtures now preload)