### PR TITLE
feat: update to legacy SDK

### DIFF
--- a/crank-counter/anchor/Anchor.toml
+++ b/crank-counter/anchor/Anchor.toml
@@ -6,7 +6,7 @@ resolution = true
 skip-lint = false
 
 [programs.devnet]
-crank_counter = "HetkBSVTbemvzJzcmnTS6Ge6LP9KVVXkbtdL6qguG2g9"
+crank_counter = "6avjV8kWVhVf2NX6ZeE7SaqyqjRnCD6JDwhiUH6yFymz"
 
 [programs.localnet]
 crank_counter = "FW2QPnTK9WwYLNG29GhH7PGYdp7Jwq3pGQrUuNdUnK44"

--- a/crank-counter/anchor/Anchor.toml
+++ b/crank-counter/anchor/Anchor.toml
@@ -9,7 +9,7 @@ skip-lint = false
 crank_counter = "6avjV8kWVhVf2NX6ZeE7SaqyqjRnCD6JDwhiUH6yFymz"
 
 [programs.localnet]
-crank_counter = "FW2QPnTK9WwYLNG29GhH7PGYdp7Jwq3pGQrUuNdUnK44"
+crank_counter = "6avjV8kWVhVf2NX6ZeE7SaqyqjRnCD6JDwhiUH6yFymz"
 
 [provider]
 cluster = "devnet"

--- a/crank-counter/anchor/Cargo.lock
+++ b/crank-counter/anchor/Cargo.lock
@@ -158,7 +158,7 @@ dependencies = [
  "anchor-derive-space",
  "anchor-lang-idl",
  "base64 0.21.7",
- "bincode",
+ "bincode 1.3.3",
  "borsh 1.6.0",
  "bytemuck",
  "const-crypto",
@@ -290,6 +290,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
 ]
 
 [[package]]
@@ -571,9 +590,8 @@ name = "crank-counter"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
- "bincode",
+ "bincode 1.3.3",
  "ephemeral-rollups-sdk",
- "magicblock-magic-program-api",
  "sha2 0.10.9",
 ]
 
@@ -733,14 +751,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "ephemeral-rollups-sdk"
-version = "0.16.2"
+name = "ephemeral-rollups-pinocchio"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a267fd1fe36f82ed50307b3757561ac59b1629a523fd179e2a66f4383c9afc0a"
+checksum = "a09b61c47e5b4eeb7add34e9d43d836784a66d78fa704606bebaa453bef73e21"
+dependencies = [
+ "bincode 2.0.1",
+ "pinocchio 0.10.2",
+ "pinocchio-pubkey",
+ "pinocchio-system",
+ "solana-address 2.6.0",
+]
+
+[[package]]
+name = "ephemeral-rollups-sdk"
+version = "0.16.0"
+source = "git+https://github.com/magicblock-labs/ephemeral-rollups-sdk.git?rev=086eeaa0e9fcd12d442d78bcd40817a782521cbc#086eeaa0e9fcd12d442d78bcd40817a782521cbc"
 dependencies = [
  "anchor-lang",
  "base64ct",
- "bincode",
+ "bincode 1.3.3",
  "bytemuck",
  "ephemeral-rollups-sdk-attribute-action",
  "ephemeral-rollups-sdk-attribute-commit",
@@ -751,6 +781,7 @@ dependencies = [
  "ephemeral-vrf-sdk-vrf-macro",
  "five8 0.2.1",
  "getrandom 0.2.16",
+ "hydra-api",
  "magicblock-delegation-program-api",
  "magicblock-magic-program-api",
  "solana-account-info 2.3.0",
@@ -763,9 +794,8 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-action"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3847b70bac1717bfd3108fe310195e658665b2d971bcb4eb2aa5aaca2c9392"
+version = "0.16.0"
+source = "git+https://github.com/magicblock-labs/ephemeral-rollups-sdk.git?rev=086eeaa0e9fcd12d442d78bcd40817a782521cbc#086eeaa0e9fcd12d442d78bcd40817a782521cbc"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -773,9 +803,8 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-commit"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b08e06840701468449f75916e922fd9694b787596efe66cd9b8dccf3ef0eb5e6"
+version = "0.16.0"
+source = "git+https://github.com/magicblock-labs/ephemeral-rollups-sdk.git?rev=086eeaa0e9fcd12d442d78bcd40817a782521cbc#086eeaa0e9fcd12d442d78bcd40817a782521cbc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -784,9 +813,8 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-delegate"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc365676345c77eed3651debb63af9b282902100e5852a1822ee1385e3b285fe"
+version = "0.16.0"
+source = "git+https://github.com/magicblock-labs/ephemeral-rollups-sdk.git?rev=086eeaa0e9fcd12d442d78bcd40817a782521cbc#086eeaa0e9fcd12d442d78bcd40817a782521cbc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -795,9 +823,8 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-ephemeral"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce2590d04b16345a3117c0b66b6822a96a5ef3bc7b9add073cb3a797529d8df"
+version = "0.16.0"
+source = "git+https://github.com/magicblock-labs/ephemeral-rollups-sdk.git?rev=086eeaa0e9fcd12d442d78bcd40817a782521cbc#086eeaa0e9fcd12d442d78bcd40817a782521cbc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -806,9 +833,8 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-ephemeral-accounts"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f70d4bbf6761a71df97fbadcb4cceef630e2d6e37189f5e674ff34bb2210823"
+version = "0.16.0"
+source = "git+https://github.com/magicblock-labs/ephemeral-rollups-sdk.git?rev=086eeaa0e9fcd12d442d78bcd40817a782521cbc#086eeaa0e9fcd12d442d78bcd40817a782521cbc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1022,6 +1048,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hydra-api"
+version = "0.1.1"
+source = "git+https://github.com/magicblock-labs/hydra.git?rev=4f9e3c44e9e2e4feab66e6e7903099e095c74db3#4f9e3c44e9e2e4feab66e6e7903099e095c74db3"
+dependencies = [
+ "ephemeral-rollups-pinocchio",
+ "pinocchio 0.10.2",
+ "solana-account-info 3.1.1",
+ "solana-address 2.6.0",
+ "solana-cpi 3.1.0",
+ "solana-instruction 3.4.0",
+ "solana-program-error 3.0.0",
+ "solana-pubkey 4.2.0",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,7 +1202,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bea16e41e04319201919afca98dd4241b18549f2db0c68f58e4bc531537b5dab"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "borsh 0.10.4",
  "borsh 1.6.0",
  "bytemuck",
@@ -1192,7 +1233,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dc8fba0307c90b91b70c9ed06d4242d6c4159f331b2f05bf8f875c2a94e0e98"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "const-crypto",
  "serde",
  "solana-program 3.0.0",
@@ -1825,7 +1866,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8f5152a288ef1912300fc6efa6c2d1f9bb55d9398eb6c72326360b8063987da"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "serde",
  "solana-program-error 2.2.2",
  "solana-program-memory 2.3.1",
@@ -1838,7 +1879,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9cf16495d9eb53e3d04e72366a33bb1c20c24e78c171d8b8f5978357b63ae95"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "serde_core",
  "solana-address 2.6.0",
  "solana-program-error 3.0.0",
@@ -1893,7 +1934,7 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1673f67efe870b64a65cb39e6194be5b26527691ce5922909939961a6e6b395"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "bytemuck",
  "serde",
  "serde_derive",
@@ -1962,7 +2003,7 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19a3787b8cf9c9fe3dd360800e8b70982b9e5a8af9e11c354b6665dd4a003adc"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "serde",
  "solana-instruction 2.3.3",
 ]
@@ -2198,7 +2239,7 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43f5c5382b449e8e4e3016fb05e418c53d57782d8b5c30aa372fc265654b956d"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "serde",
  "serde_derive",
  "solana-account",
@@ -2293,7 +2334,7 @@ version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab5682934bd1f65f8d2c16f21cb532526fcc1a09f796e2cacdb091eee5774ad"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "getrandom 0.2.16",
  "js-sys",
  "num-traits",
@@ -2311,7 +2352,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ebb0ffd19263051bc3f683fcc086134b8ff23af894dcb63f7563c7137b42f1"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "borsh 1.6.0",
  "serde",
  "serde_derive",
@@ -2504,7 +2545,7 @@ version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1796aabce376ff74bf89b78d268fa5e683d7d7a96a0a4e4813ec34de49d5314b"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "blake3",
  "lazy_static",
  "serde",
@@ -2601,7 +2642,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98eca145bd3545e2fbb07166e895370576e47a00a7d824e325390d33bf467210"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "blake3",
  "bs58",
  "bytemuck",
@@ -3220,7 +3261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8c3595f95069f3d90f275bb9bd235a1973c4d059028b0a7f81baca2703815db"
 dependencies = [
  "base64 0.22.1",
- "bincode",
+ "bincode 1.3.3",
  "bytemuck",
  "bytemuck_derive",
  "lazy_static",
@@ -3257,7 +3298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6690d3dd88f15c21edff68eb391ef8800df7a1f5cec84ee3e8d1abf05affdf74"
 dependencies = [
  "base64 0.22.1",
- "bincode",
+ "bincode 1.3.3",
  "bytemuck",
  "bytemuck_derive",
  "lazy_static",
@@ -3330,7 +3371,7 @@ version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b80d57478d6599d30acc31cc5ae7f93ec2361a06aefe8ea79bc81739a08af4c3"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "num-derive",
  "num-traits",
  "serde",
@@ -3579,6 +3620,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "uuid"
 version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3593,6 +3640,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wasi"

--- a/crank-counter/anchor/Cargo.lock
+++ b/crank-counter/anchor/Cargo.lock
@@ -766,7 +766,7 @@ dependencies = [
 [[package]]
 name = "ephemeral-rollups-sdk"
 version = "0.16.0"
-source = "git+https://github.com/magicblock-labs/ephemeral-rollups-sdk.git?rev=086eeaa0e9fcd12d442d78bcd40817a782521cbc#086eeaa0e9fcd12d442d78bcd40817a782521cbc"
+source = "git+https://github.com/magicblock-labs/ephemeral-rollups-sdk.git?rev=0fc4604157de51df28693e02e5a1a6a4a08c8a03#0fc4604157de51df28693e02e5a1a6a4a08c8a03"
 dependencies = [
  "anchor-lang",
  "base64ct",
@@ -795,7 +795,7 @@ dependencies = [
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-action"
 version = "0.16.0"
-source = "git+https://github.com/magicblock-labs/ephemeral-rollups-sdk.git?rev=086eeaa0e9fcd12d442d78bcd40817a782521cbc#086eeaa0e9fcd12d442d78bcd40817a782521cbc"
+source = "git+https://github.com/magicblock-labs/ephemeral-rollups-sdk.git?rev=0fc4604157de51df28693e02e5a1a6a4a08c8a03#0fc4604157de51df28693e02e5a1a6a4a08c8a03"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -804,7 +804,7 @@ dependencies = [
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-commit"
 version = "0.16.0"
-source = "git+https://github.com/magicblock-labs/ephemeral-rollups-sdk.git?rev=086eeaa0e9fcd12d442d78bcd40817a782521cbc#086eeaa0e9fcd12d442d78bcd40817a782521cbc"
+source = "git+https://github.com/magicblock-labs/ephemeral-rollups-sdk.git?rev=0fc4604157de51df28693e02e5a1a6a4a08c8a03#0fc4604157de51df28693e02e5a1a6a4a08c8a03"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-delegate"
 version = "0.16.0"
-source = "git+https://github.com/magicblock-labs/ephemeral-rollups-sdk.git?rev=086eeaa0e9fcd12d442d78bcd40817a782521cbc#086eeaa0e9fcd12d442d78bcd40817a782521cbc"
+source = "git+https://github.com/magicblock-labs/ephemeral-rollups-sdk.git?rev=0fc4604157de51df28693e02e5a1a6a4a08c8a03#0fc4604157de51df28693e02e5a1a6a4a08c8a03"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -824,7 +824,7 @@ dependencies = [
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-ephemeral"
 version = "0.16.0"
-source = "git+https://github.com/magicblock-labs/ephemeral-rollups-sdk.git?rev=086eeaa0e9fcd12d442d78bcd40817a782521cbc#086eeaa0e9fcd12d442d78bcd40817a782521cbc"
+source = "git+https://github.com/magicblock-labs/ephemeral-rollups-sdk.git?rev=0fc4604157de51df28693e02e5a1a6a4a08c8a03#0fc4604157de51df28693e02e5a1a6a4a08c8a03"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -834,7 +834,7 @@ dependencies = [
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-ephemeral-accounts"
 version = "0.16.0"
-source = "git+https://github.com/magicblock-labs/ephemeral-rollups-sdk.git?rev=086eeaa0e9fcd12d442d78bcd40817a782521cbc#086eeaa0e9fcd12d442d78bcd40817a782521cbc"
+source = "git+https://github.com/magicblock-labs/ephemeral-rollups-sdk.git?rev=0fc4604157de51df28693e02e5a1a6a4a08c8a03#0fc4604157de51df28693e02e5a1a6a4a08c8a03"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crank-counter/anchor/Cargo.lock
+++ b/crank-counter/anchor/Cargo.lock
@@ -590,9 +590,7 @@ name = "crank-counter"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
- "bincode 1.3.3",
  "ephemeral-rollups-sdk",
- "sha2 0.10.9",
 ]
 
 [[package]]

--- a/crank-counter/anchor/programs/crank-counter/Cargo.toml
+++ b/crank-counter/anchor/programs/crank-counter/Cargo.toml
@@ -22,11 +22,16 @@ custom-panic = []
 
 [dependencies]
 anchor-lang = { version = "1.0.2", features = ["init-if-needed"] }
-ephemeral-rollups-sdk = { version = "0.16.2", features = ["anchor"] }
+# TODO: Remove this once the SDK is published to crates.io
+ephemeral-rollups-sdk = { git = "https://github.com/magicblock-labs/ephemeral-rollups-sdk.git", rev = "086eeaa0e9fcd12d442d78bcd40817a782521cbc", features = [
+    "anchor",
+    "crank",
+] }
 sha2 = "0.10"
-magicblock-magic-program-api = { version = "0.10.1", default-features = false }
 bincode = "^1.3"
 
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(target_os, values("solana"))'] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(target_os, values("solana"))',
+] }

--- a/crank-counter/anchor/programs/crank-counter/Cargo.toml
+++ b/crank-counter/anchor/programs/crank-counter/Cargo.toml
@@ -23,7 +23,7 @@ custom-panic = []
 [dependencies]
 anchor-lang = { version = "1.0.2", features = ["init-if-needed"] }
 # TODO: Remove this once the SDK is published to crates.io
-ephemeral-rollups-sdk = { git = "https://github.com/magicblock-labs/ephemeral-rollups-sdk.git", rev = "086eeaa0e9fcd12d442d78bcd40817a782521cbc", features = [
+ephemeral-rollups-sdk = { git = "https://github.com/magicblock-labs/ephemeral-rollups-sdk.git", rev = "0fc4604157de51df28693e02e5a1a6a4a08c8a03", features = [
     "anchor",
     "crank",
 ] }

--- a/crank-counter/anchor/programs/crank-counter/Cargo.toml
+++ b/crank-counter/anchor/programs/crank-counter/Cargo.toml
@@ -27,8 +27,6 @@ ephemeral-rollups-sdk = { git = "https://github.com/magicblock-labs/ephemeral-ro
     "anchor",
     "crank",
 ] }
-sha2 = "0.10"
-bincode = "^1.3"
 
 
 [lints.rust]

--- a/crank-counter/anchor/programs/crank-counter/src/lib.rs
+++ b/crank-counter/anchor/programs/crank-counter/src/lib.rs
@@ -42,8 +42,8 @@ pub mod anchor_counter {
     }
 
     // Schedules crank for increment counter
-    pub fn schedule_increment(
-        ctx: Context<ScheduleIncrement>,
+    pub fn schedule_increment<'info>(
+        ctx: Context<'info, ScheduleIncrement<'info>>,
         args: ScheduleIncrementArgs,
     ) -> Result<()> {
         let increment_ix = Instruction {
@@ -53,8 +53,8 @@ pub mod anchor_counter {
         };
 
         ScheduleCrankCpi {
-            payer: ctx.accounts.payer.to_account_info(),
-            magic_program: ctx.accounts.magic_program.to_account_info(),
+            payer: &ctx.accounts.payer,
+            magic_program: &&ctx.accounts.magic_program,
             instruction_accounts: &[
                 ctx.accounts.payer.to_account_info(),
                 ctx.accounts.counter.to_account_info(),

--- a/crank-counter/anchor/programs/crank-counter/src/lib.rs
+++ b/crank-counter/anchor/programs/crank-counter/src/lib.rs
@@ -3,14 +3,10 @@ use ephemeral_rollups_sdk::anchor::{commit, delegate, ephemeral};
 use ephemeral_rollups_sdk::cpi::DelegateConfig;
 use ephemeral_rollups_sdk::ephem::MagicIntentBundleBuilder;
 
-use anchor_lang::solana_program::{
-    instruction::{AccountMeta, Instruction},
-    program::invoke_signed,
-};
-use ephemeral_rollups_sdk::consts::MAGIC_PROGRAM_ID;
-use magicblock_magic_program_api::{args::ScheduleTaskArgs, instruction::MagicBlockInstruction};
+use anchor_lang::solana_program::instruction::{AccountMeta, Instruction};
+use ephemeral_rollups_sdk::crank::{ScheduleCrankCpi, ScheduleTaskArgs};
 
-declare_id!("HetkBSVTbemvzJzcmnTS6Ge6LP9KVVXkbtdL6qguG2g9");
+declare_id!("6avjV8kWVhVf2NX6ZeE7SaqyqjRnCD6JDwhiUH6yFymz");
 
 pub const COUNTER_SEED: &[u8] = b"counter";
 
@@ -56,34 +52,21 @@ pub mod anchor_counter {
             data: anchor_lang::InstructionData::data(&crate::instruction::Increment {}),
         };
 
-        let ix_data = bincode::serialize(&MagicBlockInstruction::ScheduleTask(ScheduleTaskArgs {
-            task_id: args.task_id,
-            execution_interval_millis: args.execution_interval_millis,
-            iterations: args.iterations,
-            instructions: vec![increment_ix],
-        }))
-        .map_err(|err| {
-            msg!("ERROR: failed to serialize args {:?}", err);
-            ProgramError::InvalidArgument
-        })?;
-
-        let schedule_ix = Instruction::new_with_bytes(
-            MAGIC_PROGRAM_ID,
-            &ix_data,
-            vec![
-                AccountMeta::new(ctx.accounts.payer.key(), true),
-                AccountMeta::new(ctx.accounts.counter.key(), false),
-            ],
-        );
-
-        invoke_signed(
-            &schedule_ix,
-            &[
+        ScheduleCrankCpi {
+            payer: ctx.accounts.payer.to_account_info(),
+            magic_program: ctx.accounts.magic_program.to_account_info(),
+            instruction_accounts: &[
                 ctx.accounts.payer.to_account_info(),
                 ctx.accounts.counter.to_account_info(),
             ],
-            &[],
-        )?;
+            args: ScheduleTaskArgs {
+                task_id: args.task_id,
+                execution_interval_millis: args.execution_interval_millis,
+                iterations: args.iterations,
+                instructions: vec![increment_ix],
+            },
+        }
+        .invoke()?;
 
         Ok(())
     }

--- a/crank-counter/anchor/tests/crank-counter.ts
+++ b/crank-counter/anchor/tests/crank-counter.ts
@@ -3,6 +3,8 @@ import { BN, Program, web3 } from "@coral-xyz/anchor";
 import { AnchorCounter } from "../target/types/anchor_counter";
 import { LAMPORTS_PER_SOL } from "@solana/web3.js";
 import { MAGIC_PROGRAM_ID } from "@magicblock-labs/ephemeral-rollups-sdk";
+import idl from "../target/idl/anchor_counter.json";
+import { expect } from "chai";
 
 const COUNTER_SEED = "counter";
 
@@ -39,6 +41,10 @@ describe("crank-counter", () => {
   });
 
   const program = anchor.workspace.AnchorCounter as Program<AnchorCounter>;
+  const programEphemeral = new anchor.Program<AnchorCounter>(
+    idl,
+    providerEphemeralRollup,
+  );
   const [counterPDA] = anchor.web3.PublicKey.findProgramAddressSync(
     [Buffer.from(COUNTER_SEED)],
     program.programId,
@@ -48,18 +54,16 @@ describe("crank-counter", () => {
   console.log("Counter PDA: ", counterPDA.toString());
 
   it("Initialize counter on Solana", async () => {
-    let tx = await program.methods
+    const txHash = await program.methods
       .initialize()
       .accounts({
         user: provider.wallet.publicKey,
       })
-      .transaction();
-
-    const txHash = await provider.sendAndConfirm(tx, [provider.wallet.payer], {
-      skipPreflight: true,
-      commitment: "confirmed",
-    });
+      .rpc({ skipPreflight: true, commitment: "confirmed" });
     console.log(`[Base Layer] Initialize txHash: ${txHash}`);
+
+    const counter = await program.account.counter.fetch(counterPDA);
+    expect(counter.count.toNumber()).to.equal(0);
   });
 
   it("Delegate counter to ER", async () => {
@@ -76,26 +80,22 @@ describe("crank-counter", () => {
     const remainingAccounts = validatorPubkey
       ? [{ pubkey: validatorPubkey, isSigner: false, isWritable: false }]
       : [];
-    let tx = await program.methods
+    const txHash = await program.methods
       .delegate()
       .accounts({
         payer: provider.wallet.publicKey,
         pda: counterPDA,
       })
       .remainingAccounts(remainingAccounts)
-      .transaction();
-    const txHash = await provider.sendAndConfirm(tx, [provider.wallet.payer], {
-      skipPreflight: true,
-      commitment: "confirmed",
-    });
+      .rpc({ skipPreflight: true, commitment: "confirmed" });
     console.log(`[Base Layer] Delegate txHash: ${txHash}`);
   });
 
   it("Schedule increment counter on ER", async () => {
-    let tx = await program.methods
+    const txHash = await programEphemeral.methods
       .scheduleIncrement({
         taskId: new BN(1), // Task ID can be arbitrary, used mostly to cancel cranks.
-        executionIntervalMillis: new BN(100), // Milliseconds between executions.
+        executionIntervalMillis: new BN(1000), // Milliseconds between executions.
         iterations: new BN(3), // Number of times to execute the task.
       })
       .accounts({
@@ -103,35 +103,29 @@ describe("crank-counter", () => {
         payer: providerEphemeralRollup.wallet.publicKey,
         program: program.programId,
       })
-      .transaction();
-    tx.feePayer = providerEphemeralRollup.wallet.publicKey;
-    tx.recentBlockhash = (
-      await providerEphemeralRollup.connection.getLatestBlockhash()
-    ).blockhash;
-    tx = await providerEphemeralRollup.wallet.signTransaction(tx);
-
-    const txHash = await providerEphemeralRollup.sendAndConfirm(tx, [], {
-      skipPreflight: true,
-      commitment: "confirmed",
-    });
+      .rpc({ skipPreflight: true, commitment: "confirmed" });
     console.log(`[ER] Schedule Increment txHash: ${txHash}`);
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    const timeout = 10_000; // 10 seconds max wait
+    const pollInterval = 100;
+    const startTime = Date.now();
+    let counter = await programEphemeral.account.counter.fetch(counterPDA);
+    while (counter.count.toNumber() < 2) {
+      if (Date.now() - startTime > timeout) {
+        throw new Error("Timed out waiting for counter to increment");
+      }
+      await new Promise((resolve) => setTimeout(resolve, pollInterval));
+      counter = await programEphemeral.account.counter.fetch(counterPDA);
+    }
   });
 
   it("Undelegate counter on ER to Solana", async () => {
-    let tx = await program.methods
+    const txHash = await programEphemeral.methods
       .undelegate()
       .accounts({
         payer: providerEphemeralRollup.wallet.publicKey,
       })
-      .transaction();
-    tx.feePayer = provider.wallet.publicKey;
-    tx.recentBlockhash = (
-      await providerEphemeralRollup.connection.getLatestBlockhash()
-    ).blockhash;
-    tx = await providerEphemeralRollup.wallet.signTransaction(tx);
-
-    const txHash = await providerEphemeralRollup.sendAndConfirm(tx);
+      .rpc({ skipPreflight: true, commitment: "confirmed" });
     console.log(`[ER] Undelegate txHash: ${txHash}`);
   });
 

--- a/rewards-delegated-vrf/anchor/dashboard/lib/clusterContext.ts
+++ b/rewards-delegated-vrf/anchor/dashboard/lib/clusterContext.ts
@@ -3,10 +3,7 @@
  * Provides cluster information and utilities for the application
  */
 
-import {
-  SOLANA_DEVNET_ENDPOINT,
-  SOLANA_MAINNET_ENDPOINT,
-} from "./endpoints";
+import { SOLANA_DEVNET_ENDPOINT, SOLANA_MAINNET_ENDPOINT } from "./endpoints";
 
 export { getBaseLayerSolanaEndpoint } from "./endpoints";
 
@@ -161,4 +158,3 @@ export function getDefaultSolanaEndpoint(): string {
 export function getDefaultMagicBlockErEndpoint(): string {
   return CLUSTER_CONFIG["https://devnet-as.magicblock.app/"].endpoint;
 }
-

--- a/roll-dice/anchor/app/lib/roll-result.test.ts
+++ b/roll-dice/anchor/app/lib/roll-result.test.ts
@@ -1,75 +1,82 @@
-import assert from "node:assert/strict"
-import { describe, it } from "node:test"
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
 import {
   requiresLiveRollCorrelation,
   shouldCompleteRoll,
   type RollResultSource,
-} from "./roll-result.ts"
+} from "./roll-result.ts";
 
 const completion = (
   overrides: Partial<Parameters<typeof shouldCompleteRoll>[0]> = {},
-) => shouldCompleteRoll({
-  source: "subscription",
-  isPending: true,
-  activeGeneration: 4,
-  startRollnum: 12,
-  newRollnum: 13,
-  newValue: 6,
-  hasRequestSignature: true,
-  requestSlot: null,
-  observedSlot: 101,
-  ...overrides,
-})
+) =>
+  shouldCompleteRoll({
+    source: "subscription",
+    isPending: true,
+    activeGeneration: 4,
+    startRollnum: 12,
+    newRollnum: 13,
+    newValue: 6,
+    hasRequestSignature: true,
+    requestSlot: null,
+    observedSlot: 101,
+    ...overrides,
+  });
 
 describe("shouldCompleteRoll", () => {
   it("uses a rollnum-advancing account subscription as the fast path", () => {
-    assert.equal(completion(), true)
-  })
+    assert.equal(completion(), true);
+  });
 
   it("rejects stale, unchanged, and pre-request subscription updates", () => {
-    assert.equal(completion({ newRollnum: 12 }), false)
-    assert.equal(completion({ newRollnum: 11 }), false)
-    assert.equal(completion({ hasRequestSignature: false }), false)
-    assert.equal(completion({ startRollnum: null }), false)
-    assert.equal(completion({ requestSlot: 102, observedSlot: 101 }), false)
-    assert.equal(completion({ requestSlot: 101, observedSlot: 101 }), true)
-  })
+    assert.equal(completion({ newRollnum: 12 }), false);
+    assert.equal(completion({ newRollnum: 11 }), false);
+    assert.equal(completion({ hasRequestSignature: false }), false);
+    assert.equal(completion({ startRollnum: null }), false);
+    assert.equal(completion({ requestSlot: 102, observedSlot: 101 }), false);
+    assert.equal(completion({ requestSlot: 101, observedSlot: 101 }), true);
+  });
 
   it("does not let sync, polling, or warm-up updates complete a user roll", () => {
     for (const source of ["sync", "poll"] satisfies RollResultSource[]) {
-      assert.equal(completion({ source }), false)
+      assert.equal(completion({ source }), false);
     }
-    assert.equal(completion({ isPending: false }), false)
-  })
+    assert.equal(completion({ isPending: false }), false);
+  });
 
   it("keeps a saturated counter on the correlated callback path", () => {
-    assert.equal(completion({ startRollnum: 255, newRollnum: 255 }), false)
-  })
+    assert.equal(completion({ startRollnum: 255, newRollnum: 255 }), false);
+  });
 
   it("requires the callback to match the active roll generation", () => {
-    assert.equal(completion({
-      source: "callback",
-      observedGeneration: 4,
-      startRollnum: 255,
-      newRollnum: 255,
-    }), true)
-    assert.equal(completion({
-      source: "callback",
-      observedGeneration: 3,
-      startRollnum: 255,
-      newRollnum: 255,
-    }), false)
-  })
-})
+    assert.equal(
+      completion({
+        source: "callback",
+        observedGeneration: 4,
+        startRollnum: 255,
+        newRollnum: 255,
+      }),
+      true,
+    );
+    assert.equal(
+      completion({
+        source: "callback",
+        observedGeneration: 3,
+        startRollnum: 255,
+        newRollnum: 255,
+      }),
+      false,
+    );
+  });
+});
 
 describe("requiresLiveRollCorrelation", () => {
   it("keeps ordinary single-in-flight rolls on the account-only hot path", () => {
-    assert.equal(requiresLiveRollCorrelation(96, 1), false)
-  })
+    assert.equal(requiresLiveRollCorrelation(96, 1), false);
+  });
 
   it("enables live correlation for ambiguous account updates", () => {
-    assert.equal(requiresLiveRollCorrelation(null, 1), true)
-    assert.equal(requiresLiveRollCorrelation(255, 1), true)
-    assert.equal(requiresLiveRollCorrelation(96, 2), true)
-  })
-})
+    assert.equal(requiresLiveRollCorrelation(null, 1), true);
+    assert.equal(requiresLiveRollCorrelation(255, 1), true);
+    assert.equal(requiresLiveRollCorrelation(96, 2), true);
+  });
+});

--- a/roll-dice/anchor/app/lib/roll-result.ts
+++ b/roll-dice/anchor/app/lib/roll-result.ts
@@ -1,26 +1,26 @@
-export type RollResultSource = "subscription" | "sync" | "poll" | "callback"
+export type RollResultSource = "subscription" | "sync" | "poll" | "callback";
 
 export function requiresLiveRollCorrelation(
   startRollnum: number | null,
   unavailableClientSeeds: number,
 ): boolean {
-  return startRollnum === null ||
-    startRollnum >= 255 ||
-    unavailableClientSeeds > 1
+  return (
+    startRollnum === null || startRollnum >= 255 || unavailableClientSeeds > 1
+  );
 }
 
 type RollResultCompletion = {
-  source: RollResultSource
-  isPending: boolean
-  activeGeneration: number
-  observedGeneration?: number
-  startRollnum: number | null
-  newRollnum: number
-  newValue: number
-  hasRequestSignature: boolean
-  requestSlot: number | null
-  observedSlot?: number
-}
+  source: RollResultSource;
+  isPending: boolean;
+  activeGeneration: number;
+  observedGeneration?: number;
+  startRollnum: number | null;
+  newRollnum: number;
+  newValue: number;
+  hasRequestSignature: boolean;
+  requestSlot: number | null;
+  observedSlot?: number;
+};
 
 /**
  * Account subscriptions are the lowest-latency signal, but the player account
@@ -43,10 +43,10 @@ export function shouldCompleteRoll({
   requestSlot,
   observedSlot,
 }: RollResultCompletion): boolean {
-  if (!isPending || newValue <= 0) return false
+  if (!isPending || newValue <= 0) return false;
 
   if (source === "callback") {
-    return observedGeneration === activeGeneration
+    return observedGeneration === activeGeneration;
   }
 
   if (
@@ -55,9 +55,12 @@ export function shouldCompleteRoll({
     startRollnum === null ||
     startRollnum >= 255 ||
     newRollnum <= startRollnum
-  ) return false
+  )
+    return false;
 
-  return requestSlot === null ||
+  return (
+    requestSlot === null ||
     observedSlot === undefined ||
     observedSlot >= requestSlot
+  );
 }

--- a/scripts/mAGicPQYBMvcYveUZA5F5UNNwyHvfYh5xkLS2Fr1mev.json
+++ b/scripts/mAGicPQYBMvcYveUZA5F5UNNwyHvfYh5xkLS2Fr1mev.json
@@ -1,0 +1,14 @@
+{
+  "pubkey": "mAGicPQYBMvcYveUZA5F5UNNwyHvfYh5xkLS2Fr1mev",
+  "account": {
+    "lamports": 9753447155,
+    "data": [
+      "",
+      "base64"
+    ],
+    "owner": "11111111111111111111111111111111",
+    "executable": false,
+    "rentEpoch": 18446744073709551615,
+    "space": 0
+  }
+}

--- a/scripts/test-locally.sh
+++ b/scripts/test-locally.sh
@@ -594,7 +594,7 @@ fi
 # <name>-keypair.json, add an upgradeable program at the keypair's address with the
 # local wallet as upgrade authority — mirroring what `anchor deploy` /
 # `solana program deploy` produced before.
-PRELOAD_ARGS=()
+PRELOAD_ARGS=(--account mAGicPQYBMvcYveUZA5F5UNNwyHvfYh5xkLS2Fr1mev "$SCRIPT_DIR/mAGicPQYBMvcYveUZA5F5UNNwyHvfYh5xkLS2Fr1mev.json")
 WALLET_PUBKEY=$(solana-keygen pubkey "$HOME/.config/solana/id.json" 2>/dev/null || echo "")
 if [ "${#BUILD_PROJECTS[@]}" -gt 0 ]; then
   echo "Preloading programs into mb-test-validator:"


### PR DESCRIPTION
The current example manually builds the crank schedule. Uses the SDK instead (legacy cranks, not Hydra)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the crank counter to use the latest scheduling workflow for recurring increments.
  - Added support for preloading an account fixture during local development.

- **Bug Fixes**
  - Improved scheduled increment reliability by waiting for on-chain updates instead of relying on a fixed delay.

- **Tests**
  - Enhanced integration checks to verify initialization, delegation, scheduled increments, and undelegation results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->